### PR TITLE
Update cokriging.py according to the new OpenMEASURE

### DIFF
--- a/src/openmeasure/cokriging.py
+++ b/src/openmeasure/cokriging.py
@@ -13,7 +13,7 @@ MODULE: cokriging.py
 
 #%%
 import numpy as np
-import sparse_sensing as sps
+import openmeasure.sparse_sensing as sps
 from openmdao.surrogate_models.multifi_cokriging import MultiFiCoKriging
 
 class CoKriging():


### PR DESCRIPTION
sparse_sensing is called openmeasure.sparse_sensing in new OpenMEASURE, so line 16 is corrected accordingly.